### PR TITLE
Added Signs Redstone & Block, per Player messages, fixes & additions

### DIFF
--- a/src/com/dre/dungeonsxl/game/GameWorld.java
+++ b/src/com/dre/dungeonsxl/game/GameWorld.java
@@ -51,6 +51,7 @@ public class GameWorld {
 	public CopyOnWriteArrayList<DMob> dmobs = new CopyOnWriteArrayList<DMob>();
 	public CopyOnWriteArrayList<GameChest> gchests = new CopyOnWriteArrayList<GameChest>();
 	public CopyOnWriteArrayList<DSign> dSigns = new CopyOnWriteArrayList<DSign>();
+	public CopyOnWriteArrayList<Block> untouchable = new CopyOnWriteArrayList<Block>();
 	public DConfig config;
 	
 
@@ -99,6 +100,9 @@ public class GameWorld {
 						dSign.onUpdate(0,false);
 					}
 				}
+				if(!dSign.isRedstoneTrigger() && !dSign.isDistanceTrigger() && !dSign.isSignTrigger()){
+					dSign.onTrigger();
+				}
 			}
 		}
 	}
@@ -122,11 +126,7 @@ public class GameWorld {
 
 	public static void deleteAll(){
 		for(GameWorld gworld:gworlds){
-			gworlds.remove(gworld);
-
-			p.getServer().unloadWorld(gworld.world,true);
-			File dir = new File("DXL_Game_"+gworld.id);
-			p.removeDirectory(dir);
+			gworld.delete();
 		}
 	}
 
@@ -171,6 +171,11 @@ public class GameWorld {
 	public void delete(){
 		gworlds.remove(this);
 
+		for(DSign sign:dSigns){
+			if(sign != null){
+				sign.killTask();
+			}
+		}
 		p.getServer().unloadWorld(this.world,true);
 		File dir = new File("DXL_Game_"+this.id);
 		p.removeDirectory(dir);

--- a/src/com/dre/dungeonsxl/listener/EntityListener.java
+++ b/src/com/dre/dungeonsxl/listener/EntityListener.java
@@ -14,6 +14,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
+import org.bukkit.event.entity.ItemSpawnEvent;
 import org.bukkit.event.entity.EntityCombustByEntityEvent;
 import org.bukkit.event.entity.EntityCombustEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
@@ -30,6 +31,16 @@ import com.dre.dungeonsxl.game.DMob;
 import com.dre.dungeonsxl.game.GameWorld;
 
 public class EntityListener implements Listener{
+
+	//Remove drops from breaking Signs
+	@EventHandler(priority = EventPriority.HIGH)
+	public void onItemSpawn(ItemSpawnEvent event){
+		if(GameWorld.get(event.getLocation().getWorld()) != null){
+			if(event.getEntity().getItemStack().getTypeId()==323){
+				event.setCancelled(true);
+			}
+		}
+	}
 	
 	@EventHandler(priority = EventPriority.HIGH)
 	public void onCreatureSpawn(CreatureSpawnEvent event){

--- a/src/com/dre/dungeonsxl/listener/PlayerListener.java
+++ b/src/com/dre/dungeonsxl/listener/PlayerListener.java
@@ -69,10 +69,8 @@ public class PlayerListener implements Listener{
 						}
 					}
 				}
-			}
 
 			//Block invisible Redstone signs
-			if(GameWorld.get(player.getWorld())!=null){
 				GameWorld gworld = GameWorld.get(player.getWorld());
 				if(!gworld.untouchable.isEmpty()){
 					if(event.getAction()==Action.RIGHT_CLICK_BLOCK){

--- a/src/com/dre/dungeonsxl/listener/PlayerListener.java
+++ b/src/com/dre/dungeonsxl/listener/PlayerListener.java
@@ -25,6 +25,7 @@ import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.inventory.ItemStack;
 import com.dre.dungeonsxl.DGSign;
+import com.dre.dungeonsxl.signs.DSign;
 import com.dre.dungeonsxl.DGroup;
 import com.dre.dungeonsxl.DLootInventory;
 import com.dre.dungeonsxl.DPlayer;
@@ -65,6 +66,22 @@ public class PlayerListener implements Listener{
 						if(!player.isOp()){
 							p.msg(player, p.language.get("Error_Dispenser"));
 							event.setCancelled(true);
+						}
+					}
+				}
+			}
+
+			//Block invisible Redstone signs
+			if(GameWorld.get(player.getWorld())!=null){
+				GameWorld gworld = GameWorld.get(player.getWorld());
+				if(!gworld.untouchable.isEmpty()){
+					if(event.getAction()==Action.RIGHT_CLICK_BLOCK){
+						if(gworld.untouchable.contains(clickedBlock)){
+							for(DSign sign:gworld.dSigns){
+								if(sign!=null){
+									sign.onDiscover();
+								}
+							}
 						}
 					}
 				}

--- a/src/com/dre/dungeonsxl/signs/DSign.java
+++ b/src/com/dre/dungeonsxl/signs/DSign.java
@@ -91,9 +91,18 @@ public abstract class DSign {
 		
 	}
 
+	public void onDiscover(){
+		
+	}
+
 	public void onUpdate(int type,boolean powered){
 		
 	}
+
+	public void killTask(){
+		
+	}
+
 	
 	public static DSign create(Sign sign, GameWorld gworld){
 		String[] lines = sign.getLines();
@@ -127,6 +136,10 @@ public abstract class DSign {
 			dSign = new SIGNStart(sign, gworld);
 		} else if (lines[0].equalsIgnoreCase("["+SIGNTrigger.name+"]")) {
 			dSign = new SIGNTrigger(sign, gworld);
+		} else if (lines[0].equalsIgnoreCase("["+SIGNRedstone.name+"]")) {
+			dSign = new SIGNRedstone(sign, gworld);
+		} else if (lines[0].equalsIgnoreCase("["+SIGNBlock.name+"]")) {
+			dSign = new SIGNBlock(sign, gworld);
 		}
 		
 		if (dSign != null && gworld != null) {

--- a/src/com/dre/dungeonsxl/signs/SIGNBlock.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNBlock.java
@@ -1,0 +1,77 @@
+package com.dre.dungeonsxl.signs;
+
+import org.bukkit.block.Sign;
+import org.bukkit.block.Block;
+
+import com.dre.dungeonsxl.game.GameWorld;
+
+public class SIGNBlock extends DSign{
+	
+	public static String name = "Block";
+	public String buildPermissions = "dxl.sign.block";
+	public boolean onDungeonInit = false;
+	
+	//Variables
+	private boolean initialized;
+	private boolean active;
+	private byte side;
+	private int offBlock = 0;
+	private int onBlock = 0;
+
+	
+	public SIGNBlock(Sign sign, GameWorld gworld) {
+		super(sign, gworld);
+	}
+	
+	@Override
+	public boolean check() {
+		// TODO Auto-generated method stub
+		
+		return true;
+	}
+
+	@Override
+	public void onInit() {
+		String lines[] = sign.getLines();
+		offBlock = p.parseInt(lines[1]);
+		onBlock = p.parseInt(lines[2]);
+		sign.getBlock().setTypeId(offBlock);
+		initialized = true;
+	}
+
+	@Override
+	public void onUpdate(int type,boolean powered) {
+		if(initialized){
+			setPowered(type,powered);
+			if(isPowered()){
+				if(!isDistanceTrigger()){
+					onTrigger();
+				}
+			} else {
+				active = false;
+				sign.getBlock().setTypeId(offBlock);
+			}
+		}
+	}
+
+
+	@Override
+	public void onTrigger() {
+		if(initialized){
+			if(!active){
+				sign.getBlock().setTypeId(onBlock);
+				active = true;
+			}
+		}
+	}
+	
+	@Override
+	public String getPermissions() {
+		return buildPermissions;
+	}
+
+	@Override
+	public boolean isOnDungeonInit() {
+		return onDungeonInit;
+	}
+}

--- a/src/com/dre/dungeonsxl/signs/SIGNMob.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNMob.java
@@ -26,6 +26,7 @@ public class SIGNMob extends DSign{
 	private int interval = 0;
 	private int amount = 1;
 	private boolean initialized;
+	private boolean active;
 	private int id = -1;
 	
 	public SIGNMob(Sign sign, GameWorld gworld) {
@@ -62,10 +63,14 @@ public class SIGNMob extends DSign{
 	public void onUpdate(int type,boolean powered) {
 		if(initialized){
 			setPowered(type,powered);
-			if(!isDistanceTrigger()){
-				if(isPowered()){
+			if(isPowered()){
+				if(!isDistanceTrigger()){
 					onTrigger();
 				}
+			} else {
+				killTask();
+				interval = 0;
+				active = false;
 			}
 		}
 	}
@@ -73,27 +78,28 @@ public class SIGNMob extends DSign{
 	@Override
 	public void onTrigger() {
 		if(initialized){
-			MobSpawnScheduler scheduler = new MobSpawnScheduler(this);
-			
-			id = p.getServer().getScheduler().scheduleSyncRepeatingTask(p, scheduler, 0L, 20L);
-			scheduler.id = id;
-			
-			initialized = false;
+			if(!active){
+				MobSpawnScheduler scheduler = new MobSpawnScheduler(this);
+				
+				id = p.getServer().getScheduler().scheduleSyncRepeatingTask(p, scheduler, 0L, 20L);
+				
+				active = true;
+			}
 		}
 	}
 
 	@Override
 	public void killTask(){
-		//if(initialized){
+		if(initialized && active){
 			if(id != -1){
 				p.getServer().getScheduler().cancelTask(id);
+				id = -1;
 			}
-		//}
+		}
 	}
 	
 	public class MobSpawnScheduler implements Runnable{
 		private SIGNMob sign;
-		public int id;
 		
 		public MobSpawnScheduler(SIGNMob sign){
 			this.sign = sign;
@@ -133,8 +139,8 @@ public class SIGNMob extends DSign{
 					if(amount>1){
 						amount--;
 					}else{
-						p.getServer().getScheduler().cancelTask(this.id);
-						sign.gworld.dSigns.remove(this);
+						killTask();
+						sign.gworld.dSigns.remove(sign);
 					}
 				}
 				

--- a/src/com/dre/dungeonsxl/signs/SIGNMob.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNMob.java
@@ -26,6 +26,7 @@ public class SIGNMob extends DSign{
 	private int interval = 0;
 	private int amount = 1;
 	private boolean initialized;
+	private int id = -1;
 	
 	public SIGNMob(Sign sign, GameWorld gworld) {
 		super(sign, gworld);
@@ -74,11 +75,20 @@ public class SIGNMob extends DSign{
 		if(initialized){
 			MobSpawnScheduler scheduler = new MobSpawnScheduler(this);
 			
-			int id = p.getServer().getScheduler().scheduleSyncRepeatingTask(p, scheduler, 0L, 20L);
+			id = p.getServer().getScheduler().scheduleSyncRepeatingTask(p, scheduler, 0L, 20L);
 			scheduler.id = id;
 			
 			initialized = false;
 		}
+	}
+
+	@Override
+	public void killTask(){
+		//if(initialized){
+			if(id != -1){
+				p.getServer().getScheduler().cancelTask(id);
+			}
+		//}
 	}
 	
 	public class MobSpawnScheduler implements Runnable{

--- a/src/com/dre/dungeonsxl/signs/SIGNMsg.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNMsg.java
@@ -1,5 +1,7 @@
 package com.dre.dungeonsxl.signs;
 
+import java.util.concurrent.CopyOnWriteArrayList;
+
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import com.dre.dungeonsxl.game.GameWorld;
@@ -13,6 +15,7 @@ public class SIGNMsg extends DSign{
 	//Variables
 	private String msg;
 	private boolean initialized;
+	private CopyOnWriteArrayList<Player> done = new CopyOnWriteArrayList<Player>();
 	
 	public SIGNMsg(Sign sign, GameWorld gworld) {
 		super(sign, gworld);
@@ -56,10 +59,17 @@ public class SIGNMsg extends DSign{
 	public void onTrigger() {
 		if(initialized){
 			for(Player player : gworld.world.getPlayers()){
-				p.msg(player, msg);
+				if(!done.contains(player)){
+					if(!isDistanceTrigger() || player.getLocation().distance(sign.getLocation()) < getDtDistance()){
+						p.msg(player, msg);
+						done.add(player);
+					}
+				}
 			}
 			
-			this.gworld.dSigns.remove(this);
+			if(done.size() >= gworld.world.getPlayers().size()){
+				this.gworld.dSigns.remove(this);
+			}
 		}
 	}
 	

--- a/src/com/dre/dungeonsxl/signs/SIGNRedstone.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNRedstone.java
@@ -29,9 +29,7 @@ public class SIGNRedstone extends DSign{
 	@Override
 	public boolean check() {
 		if(isRedstoneTrigger()){
-			if(sign.getBlock().getType() != Material.WALL_SIGN){
-				return false;
-			}
+			return false;
 		}
 		
 		return true;
@@ -87,6 +85,7 @@ public class SIGNRedstone extends DSign{
 	public void onDiscover(){
 		if(initialized && active){
 			P.p.getServer().getScheduler().scheduleSyncDelayedTask(p, new DiscoveryTask(), 1);
+			P.p.getServer().getScheduler().scheduleSyncDelayedTask(p, new DiscoveryTask(), 5);
 		}
 	}
 
@@ -110,6 +109,7 @@ public class SIGNRedstone extends DSign{
 				active = true;
 				if(task == null){
 					task = P.p.getServer().getScheduler().runTaskTimer(p, new DiscoveryTask(), 1, 60);
+					P.p.getServer().getScheduler().scheduleSyncDelayedTask(p, new DiscoveryTask(), 5);
 				}
 			}
 		}
@@ -134,7 +134,9 @@ public class SIGNRedstone extends DSign{
 	    public void run() {
 	    	if(initialized && active){
 				for(DPlayer dplayer:DPlayer.players){
-					dplayer.player.sendBlockChange(sign.getBlock().getLocation(),0,(byte)0);
+					if(!dplayer.isEditing){
+						dplayer.player.sendBlockChange(sign.getBlock().getLocation(),0,(byte)0);
+					}
 				}
 			}
 		}

--- a/src/com/dre/dungeonsxl/signs/SIGNRedstone.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNRedstone.java
@@ -1,0 +1,143 @@
+package com.dre.dungeonsxl.signs;
+
+import org.bukkit.block.Sign;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.scheduler.BukkitTask;
+
+import com.dre.dungeonsxl.P;
+import com.dre.dungeonsxl.DPlayer;
+import com.dre.dungeonsxl.game.GameWorld;
+
+public class SIGNRedstone extends DSign{
+	
+	public static String name = "Redstone";
+	public String buildPermissions = "dxl.sign.redstone";
+	public boolean onDungeonInit = false;
+	
+	//Variables
+	private boolean initialized;
+	private boolean active;
+	private byte side;
+	private BukkitTask task = null;
+	
+	public SIGNRedstone(Sign sign, GameWorld gworld) {
+		super(sign, gworld);
+	}
+	
+	@Override
+	public boolean check() {
+		if(isRedstoneTrigger()){
+			if(sign.getBlock().getType() != Material.WALL_SIGN){
+				return false;
+			}
+		}
+		
+		return true;
+	}
+
+	@Override
+	public void onInit() {
+		if(sign.getBlock().getType() == Material.WALL_SIGN){
+			switch(sign.getData().getData()){
+				case 5:
+					side = 0x1;	//west
+					break;
+				case 4:
+					side = 0x2;	//east
+					break;
+				case 3:
+					side = 0x3;	//north
+					break;
+				case 2:
+					side = 0x4;	//south
+					break;
+			}
+		} else {
+			side = 0x5;	//up
+		}
+		gworld.untouchable.add(sign.getBlock().getRelative(BlockFace.DOWN));
+		gworld.untouchable.add(sign.getBlock().getRelative(BlockFace.UP));
+		gworld.untouchable.add(sign.getBlock().getRelative(BlockFace.WEST));
+		gworld.untouchable.add(sign.getBlock().getRelative(BlockFace.EAST));
+		gworld.untouchable.add(sign.getBlock().getRelative(BlockFace.NORTH));
+		gworld.untouchable.add(sign.getBlock().getRelative(BlockFace.SOUTH));
+		sign.getBlock().setTypeId(0);
+		initialized = true;
+	}
+
+	@Override
+	public void onUpdate(int type,boolean powered) {
+		if(initialized){
+			setPowered(type,powered);
+			if(isPowered()){
+				if(!isDistanceTrigger()){
+					onTrigger();
+				}
+			} else {
+				killTask();
+				active = false;
+				sign.getBlock().setTypeId(0);
+			}
+		}
+	}
+
+	@Override
+	public void onDiscover(){
+		if(initialized && active){
+			P.p.getServer().getScheduler().scheduleSyncDelayedTask(p, new DiscoveryTask(), 1);
+		}
+	}
+
+	@Override
+	public void killTask(){
+		if(initialized && active){
+			if(task != null){
+				task.cancel();
+				task = null;
+			}
+		}
+	}
+
+
+	@Override
+	public void onTrigger() {
+		if(initialized){
+			if(!active){
+				sign.getBlock().setData(side);
+				sign.getBlock().setTypeId(76);
+				active = true;
+				if(task == null){
+					task = P.p.getServer().getScheduler().runTaskTimer(p, new DiscoveryTask(), 1, 60);
+				}
+			}
+		}
+	}
+	
+	@Override
+	public String getPermissions() {
+		return buildPermissions;
+	}
+
+	@Override
+	public boolean isOnDungeonInit() {
+		return onDungeonInit;
+	}
+
+	public class DiscoveryTask implements Runnable  {
+
+		public DiscoveryTask() {
+	    }
+	 
+	 	@Override
+	    public void run() {
+	    	if(initialized && active){
+				for(DPlayer dplayer:DPlayer.players){
+					dplayer.player.sendBlockChange(sign.getBlock().getLocation(),0,(byte)0);
+				}
+			}
+		}
+	}
+}
+

--- a/src/com/dre/dungeonsxl/signs/SIGNSoundMsg.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNSoundMsg.java
@@ -1,5 +1,7 @@
 package com.dre.dungeonsxl.signs;
 
+import java.util.concurrent.CopyOnWriteArrayList;
+
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.getspout.spoutapi.Spout;
@@ -18,6 +20,7 @@ public class SIGNSoundMsg extends DSign{
 	//Variables
 	private boolean initialized;
 	private String msg;
+	private CopyOnWriteArrayList<Player> done = new CopyOnWriteArrayList<Player>();
 	
 	public SIGNSoundMsg(Sign sign, GameWorld gworld) {
 		super(sign, gworld);
@@ -62,14 +65,21 @@ public class SIGNSoundMsg extends DSign{
 		if(initialized){
 			if(P.p.isSpoutEnabled){
 				for(Player player : gworld.world.getPlayers()){
-					SpoutPlayer sPlayer = Spout.getServer().getPlayer(player.getName());
-					if(sPlayer.isSpoutCraftEnabled()){
-						SpoutManager.getSoundManager().playCustomMusic(P.p, sPlayer, this.msg, false, this.sign.getLocation());
+					if(!done.contains(player)){
+						if(!isDistanceTrigger() || player.getLocation().distance(sign.getLocation()) < getDtDistance()){
+							done.add(player);
+							SpoutPlayer sPlayer = Spout.getServer().getPlayer(player.getName());
+							if(sPlayer.isSpoutCraftEnabled()){
+								SpoutManager.getSoundManager().playCustomMusic(P.p, sPlayer, this.msg, false, this.sign.getLocation());
+							}
+						}
 					}
 				}
 			}
 			
-			this.gworld.dSigns.remove(this);
+			if(done.size() >= gworld.world.getPlayers().size()){
+				this.gworld.dSigns.remove(this);
+			}
 		}
 	}
 	

--- a/src/com/dre/dungeonsxl/signs/SIGNTrigger.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNTrigger.java
@@ -1,13 +1,19 @@
 package com.dre.dungeonsxl.signs;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.bukkit.block.Sign;
+import org.bukkit.block.Block;
 
 import com.dre.dungeonsxl.game.GameWorld;
+import com.dre.dungeonsxl.EditWorld;
 
 public class SIGNTrigger extends DSign{
 	public static String name = "Trigger";
 	public String buildPermissions = "dxl.sign.trigger";
 	public boolean onDungeonInit = false;
+	public static Set<Integer> used = new HashSet<Integer>();
 	
 	//Variables
 	private int triggerId;
@@ -19,6 +25,36 @@ public class SIGNTrigger extends DSign{
 
 	@Override
 	public boolean check() {
+		used.clear();
+		for(Block block : EditWorld.get(sign.getLocation().getWorld()).sign) {
+			if(block.getState() instanceof Sign){
+				Sign rsign = (Sign) block.getState();
+				if(rsign != null){
+					if(rsign.getLine(0).equalsIgnoreCase("["+name+"]")){
+						used.add(p.parseInt(rsign.getLine(1)));
+					}
+				}
+			}
+		}
+
+		int id = 1;
+		if(sign.getLine(1).equalsIgnoreCase("")){
+			if(used.size() != 0){
+				while(used.contains(id)){
+					id++;
+				}
+			}
+		} else {
+			id = p.parseInt(sign.getLine(1));
+			if(used.contains(id)){
+				return false;
+			} else {
+				return true;
+			}
+		}
+
+		sign.setLine(1, id+"");
+		p.getServer().getScheduler().scheduleSyncDelayedTask(p, new UpdateTask(), 2);
 		return true;
 	}
 	
@@ -34,7 +70,7 @@ public class SIGNTrigger extends DSign{
 	public void onUpdate(int type,boolean powered) {
 		if(initialized){
 			setPowered(type,powered);
-			if(!isDistanceTrigger()){
+			if(!isDistanceTrigger() || !isPowered()){
 				for(DSign dsign : this.gworld.dSigns){
 					if(dsign != null){
 						if(dsign.isSignTrigger()){
@@ -71,5 +107,16 @@ public class SIGNTrigger extends DSign{
 	@Override
 	public boolean isOnDungeonInit() {
 		return onDungeonInit;
+	}
+
+	public class UpdateTask implements Runnable  {
+
+		public UpdateTask() {
+	    }
+	 
+	 	@Override
+	    public void run() {
+	    	sign.update();
+	    }
 	}
 }


### PR DESCRIPTION
Hier sind noch einige Änderungen:
[block] erscheint als Block und ändert sich wenn getriggert:
1 [block]
2 Blockid vor dem triggern
3 Blockid nach dem triggern
4 D 2,T 3,R

[redstone] ist eine unsichtbare, brennende Redstonefackel, wenn getriggert.

Schilder ohne trigger sind immer getriggert
Schilder können wieder deaktiviert werden (auch mob spawner)
Messages werden nur angezeigt, wenn sie für den Spieler bestimmt sind
Schilder können übereinander gebaut werden
Unload der welt stoppt laufende scheduler
Trigger melden einen fehler, wenn die id schon vergeben ist
Gebaute Trigger ohne id übernehmen die nächste freie id
