### PR TITLE
Signchanges

### DIFF
--- a/src/com/dre/dungeonsxl/DMobType.java
+++ b/src/com/dre/dungeonsxl/DMobType.java
@@ -252,4 +252,8 @@ public class DMobType {
 
 		return null;
 	}
+
+	public String getName() {
+		return name;
+	}
 }

--- a/src/com/dre/dungeonsxl/DPlayer.java
+++ b/src/com/dre/dungeonsxl/DPlayer.java
@@ -24,7 +24,7 @@ import org.getspout.spoutapi.Spout;
 import org.getspout.spoutapi.player.SpoutPlayer;
 
 import com.dre.dungeonsxl.game.GameWorld;
-import com.dre.dungeonsxl.signs.DSign;
+import com.dre.dungeonsxl.trigger.DistanceTrigger;
 
 public class DPlayer {
 	public static P p = P.p;
@@ -489,17 +489,7 @@ public class DPlayer {
 					}
 
 					// Check Distance Trigger Signs
-					for (DSign sign : gworld.dSigns) {
-						if (sign != null) {
-							if (sign.isDistanceTrigger()) {
-								if ((sign.isRedstoneTrigger() == false && sign.isSignTrigger() == false) || sign.isPowered()) {
-									if (dplayer.player.getLocation().distance(sign.getSign().getLocation()) < sign.getDtDistance()) {
-										sign.onTrigger();
-									}
-								}
-							}
-						}
-					}
+					DistanceTrigger.triggerAllInDistance(dplayer.player, gworld);
 				}
 			}
 		}

--- a/src/com/dre/dungeonsxl/game/DMob.java
+++ b/src/com/dre/dungeonsxl/game/DMob.java
@@ -7,6 +7,7 @@ import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.inventory.ItemStack;
 
 import com.dre.dungeonsxl.DMobType;
+import com.dre.dungeonsxl.trigger.MobTrigger;
 
 public class DMob {
 
@@ -33,6 +34,7 @@ public class DMob {
 		if (event.getEntity() instanceof LivingEntity) {
 			LivingEntity victim = (LivingEntity) event.getEntity();
 			GameWorld gworld = GameWorld.get(victim.getWorld());
+			String name = null;
 
 			if (gworld != null) {
 				for (DMob dmob : gworld.dmobs) {
@@ -46,6 +48,14 @@ public class DMob {
 									event.getDrops().add(item);
 								}
 							}
+							name = dmob.type.getName();
+						} else {
+							name = victim.getType().getName();
+						}
+
+						MobTrigger trigger = MobTrigger.get(name, gworld);
+						if (trigger != null) {
+							trigger.onTrigger();
 						}
 
 						gworld.dmobs.remove(dmob);

--- a/src/com/dre/dungeonsxl/game/GameWorld.java
+++ b/src/com/dre/dungeonsxl/game/GameWorld.java
@@ -41,9 +41,6 @@ public class GameWorld {
 	public String dungeonname;
 	public Location locLobby;
 	public Location locStart;
-	public CopyOnWriteArrayList<Block> blocksEnd = new CopyOnWriteArrayList<Block>();
-	public CopyOnWriteArrayList<Block> blocksReady = new CopyOnWriteArrayList<Block>();
-	public CopyOnWriteArrayList<Block> blocksLeave = new CopyOnWriteArrayList<Block>();
 	public boolean isPlaying = false;
 	public int id;
 	public CopyOnWriteArrayList<Material> secureObjects = new CopyOnWriteArrayList<Material>();

--- a/src/com/dre/dungeonsxl/game/GameWorld.java
+++ b/src/com/dre/dungeonsxl/game/GameWorld.java
@@ -27,6 +27,7 @@ import com.dre.dungeonsxl.DPlayer;
 import com.dre.dungeonsxl.P;
 import com.dre.dungeonsxl.signs.DSign;
 import com.dre.dungeonsxl.EditWorld;
+import com.dre.dungeonsxl.trigger.RedstoneTrigger;
 
 public class GameWorld {
 	private static P p = P.p;
@@ -52,7 +53,6 @@ public class GameWorld {
 	public CopyOnWriteArrayList<DMob> dmobs = new CopyOnWriteArrayList<DMob>();
 	public CopyOnWriteArrayList<GameChest> gchests = new CopyOnWriteArrayList<GameChest>();
 	public CopyOnWriteArrayList<DSign> dSigns = new CopyOnWriteArrayList<DSign>();
-	public CopyOnWriteArrayList<Block> untouchable = new CopyOnWriteArrayList<Block>();
 	public DConfig config;
 
 	public GameWorld() {
@@ -92,16 +92,14 @@ public class GameWorld {
 				}
 			}
 		}
+		if (RedstoneTrigger.hasTriggers(this)) {
+			for (RedstoneTrigger trigger : RedstoneTrigger.getTriggersArray(this)) {
+				trigger.onTrigger();
+			}
+		}
 		for (DSign dSign : this.dSigns) {
 			if (dSign != null) {
-				if (dSign.isRedstoneTrigger()) {
-					if (dSign.getRtBlock().isBlockPowered()) {
-						dSign.onUpdate(0, true);
-					} else {
-						dSign.onUpdate(0, false);
-					}
-				}
-				if (!dSign.isRedstoneTrigger() && !dSign.isDistanceTrigger() && !dSign.isSignTrigger()) {
+				if (!dSign.hasTriggers()) {
 					dSign.onTrigger();
 				}
 			}

--- a/src/com/dre/dungeonsxl/listener/BlockListener.java
+++ b/src/com/dre/dungeonsxl/listener/BlockListener.java
@@ -23,6 +23,7 @@ import com.dre.dungeonsxl.LeaveSign;
 import com.dre.dungeonsxl.game.GamePlaceableBlock;
 import com.dre.dungeonsxl.game.GameWorld;
 import com.dre.dungeonsxl.signs.DSign;
+import com.dre.dungeonsxl.trigger.RedstoneTrigger;
 
 public class BlockListener implements Listener {
 
@@ -189,30 +190,20 @@ public class BlockListener implements Listener {
 
 	@EventHandler(priority = EventPriority.NORMAL)
 	public void onBlockRedstoneEvent(BlockRedstoneEvent event) {
-		new RedstoneEventTask(event).runTaskLater(P.p, 1);
+		new RedstoneEventTask(event.getBlock()).runTaskLater(P.p, 1);
 	}
 
 	public class RedstoneEventTask extends BukkitRunnable {
-		private final BlockRedstoneEvent event;
+		private final Block block;
 
-		public RedstoneEventTask(BlockRedstoneEvent event) {
-			this.event = event;
+		public RedstoneEventTask(final Block block) {
+			this.block = block;
 		}
 
 		public void run() {
 			for (GameWorld gworld : GameWorld.gworlds) {
-				if (event.getBlock().getWorld() == gworld.world) {
-					for (DSign sign : gworld.dSigns) {
-						if (sign != null) {
-							if (sign.isRedstoneTrigger()) {
-								if (sign.getRtBlock().isBlockPowered()) {
-									sign.onUpdate(0, true);
-								} else {
-									sign.onUpdate(0, false);
-								}
-							}
-						}
-					}
+				if (block.getWorld() == gworld.world) {
+					RedstoneTrigger.updateAll(gworld);
 				}
 			}
 		}

--- a/src/com/dre/dungeonsxl/listener/PlayerListener.java
+++ b/src/com/dre/dungeonsxl/listener/PlayerListener.java
@@ -134,44 +134,7 @@ public class PlayerListener implements Listener {
 							trigger.onTrigger(player);
 						}
 
-						// Ready Sign
-						for (Block blockReady : gworld.blocksReady) {
-							if (blockReady.getLocation().distance(clickedBlock.getLocation()) < 1) {
-								if (!dplayer.isReady) {
-									if (gworld.signClass.isEmpty() || dplayer.dclass != null) {
-										dplayer.ready();
-										p.msg(player, p.language.get("Player_Ready"));
-										return;
-									} else {
-										p.msg(player, p.language.get("Error_Ready"));
-									}
-								} else {
-									dplayer.ready();
-								}
-							}
-						}
-
-						// End Sign
-						for (Block blockEnd : gworld.blocksEnd) {
-							if (blockEnd.getLocation().distance(clickedBlock.getLocation()) < 1) {
-								if (event.getAction() == Action.LEFT_CLICK_BLOCK) {
-									dplayer.finish();
-									return;
-								} else {
-									p.msg(player, p.language.get("Error_Leftklick"));
-								}
-							}
-						}
-
-						// Leave Sign
-						for (Block blockLeave : gworld.blocksLeave) {
-							if (blockLeave.getLocation().distance(clickedBlock.getLocation()) < 1) {
-								dplayer.leave();
-							}
-						}
-
 						// Class Signs
-
 						for (Sign classSign : gworld.signClass) {
 							if (classSign != null) {
 								if (classSign.getLocation().distance(clickedBlock.getLocation()) < 1) {

--- a/src/com/dre/dungeonsxl/listener/PlayerListener.java
+++ b/src/com/dre/dungeonsxl/listener/PlayerListener.java
@@ -34,6 +34,7 @@ import com.dre.dungeonsxl.EditWorld;
 import com.dre.dungeonsxl.LeaveSign;
 import com.dre.dungeonsxl.game.GameChest;
 import com.dre.dungeonsxl.game.GameWorld;
+import com.dre.dungeonsxl.trigger.InteractTrigger;
 
 public class PlayerListener implements Listener {
 	public P p = P.p;
@@ -126,6 +127,12 @@ public class PlayerListener implements Listener {
 					// Check GameWorld Signs
 					GameWorld gworld = GameWorld.get(player.getWorld());
 					if (gworld != null) {
+
+						// Trigger InteractTrigger
+						InteractTrigger trigger = InteractTrigger.get(clickedBlock, gworld);
+						if (trigger != null) {
+							trigger.onTrigger(player);
+						}
 
 						// Ready Sign
 						for (Block blockReady : gworld.blocksReady) {

--- a/src/com/dre/dungeonsxl/signs/DSign.java
+++ b/src/com/dre/dungeonsxl/signs/DSign.java
@@ -31,13 +31,23 @@ public abstract class DSign {
 
 		// Check Trigger
 		if (gworld != null) {
-			String[] typeSplit = sign.getLine(3).split(",");
-			for (String typeSplitPart : typeSplit) {
-				String[] splitted = typeSplitPart.split(" ");
-				Trigger trigger = Trigger.getOrCreate(splitted, this);
-				if (trigger != null) {
-					trigger.addListener(this);
-					this.triggers.add(trigger);
+			String line3 = sign.getLine(3).replaceAll("\\s", "");
+			String[] triggerTypes = line3.split(",");
+
+			for (String triggerString : triggerTypes) {
+				if (!triggerString.equals("")) {
+
+					String type = triggerString.substring(0, 1);
+					String value = null;
+					if (triggerString.length() > 1) {
+						value = triggerString.substring(1);
+					}
+					
+					Trigger trigger = Trigger.getOrCreate(type, value, this);
+					if (trigger != null) {
+						trigger.addListener(this);
+						this.triggers.add(trigger);
+					}
 				}
 			}
 		}

--- a/src/com/dre/dungeonsxl/signs/DSign.java
+++ b/src/com/dre/dungeonsxl/signs/DSign.java
@@ -17,7 +17,7 @@ public abstract class DSign {
 	protected GameWorld gworld;
 
 	// List of Triggers
-	private Set<Trigger> triggers = new HashSet<Trigger>();
+	protected Set<Trigger> triggers = new HashSet<Trigger>();
 
 	public abstract boolean check();
 
@@ -30,13 +30,15 @@ public abstract class DSign {
 		this.gworld = gworld;
 
 		// Check Trigger
-		String[] typeSplit = sign.getLine(3).split(",");
-		for (String typeSplitPart : typeSplit) {
-			String[] splitted = typeSplitPart.split(" ");
-			Trigger trigger = Trigger.getOrCreate(splitted, this);
-			if (trigger != null) {
-				trigger.addListener(this);
-				this.triggers.add(trigger);
+		if (gworld != null) {
+			String[] typeSplit = sign.getLine(3).split(",");
+			for (String typeSplitPart : typeSplit) {
+				String[] splitted = typeSplitPart.split(" ");
+				Trigger trigger = Trigger.getOrCreate(splitted, this);
+				if (trigger != null) {
+					trigger.addListener(this);
+					this.triggers.add(trigger);
+				}
 			}
 		}
 	}
@@ -118,6 +120,8 @@ public abstract class DSign {
 			dSign = new SIGNStart(sign, gworld);
 		} else if (lines[0].equalsIgnoreCase("[" + SIGNTrigger.name + "]")) {
 			dSign = new SIGNTrigger(sign, gworld);
+		} else if (lines[0].equalsIgnoreCase("[" + SIGNInteract.name + "]")) {
+			dSign = new SIGNInteract(sign, gworld);
 		} else if (lines[0].equalsIgnoreCase("[" + SIGNRedstone.name + "]")) {
 			dSign = new SIGNRedstone(sign, gworld);
 		} else if (lines[0].equalsIgnoreCase("[" + SIGNBlock.name + "]")) {

--- a/src/com/dre/dungeonsxl/signs/SIGNCheckpoint.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNCheckpoint.java
@@ -1,6 +1,8 @@
 package com.dre.dungeonsxl.signs;
 
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
 
 import com.dre.dungeonsxl.DPlayer;
 import com.dre.dungeonsxl.P;
@@ -14,6 +16,7 @@ public class SIGNCheckpoint extends DSign {
 
 	// Variables
 	private boolean initialized;
+	private CopyOnWriteArrayList<DPlayer> done = new CopyOnWriteArrayList<DPlayer>();
 
 	public SIGNCheckpoint(Sign sign, GameWorld gworld) {
 		super(sign, gworld);
@@ -43,6 +46,24 @@ public class SIGNCheckpoint extends DSign {
 
 			remove();
 		}
+	}
+
+	@Override
+	public boolean onPlayerTrigger(Player player) {
+		if (initialized) {
+			DPlayer dplayer = DPlayer.get(player);
+			if (dplayer != null) {
+				if (!done.contains(dplayer)) {
+					done.add(dplayer);
+					dplayer.setCheckpoint(this.sign.getLocation());
+					P.p.msg(player, P.p.language.get("Player_CheckpointReached"));
+				}
+			}
+			if (done.size() >= DPlayer.get(this.gworld.world).size()) {
+				remove();
+			}
+		}
+		return true;
 	}
 
 	@Override

--- a/src/com/dre/dungeonsxl/signs/SIGNCheckpoint.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNCheckpoint.java
@@ -41,7 +41,7 @@ public class SIGNCheckpoint extends DSign {
 				P.p.msg(dplayer.player, P.p.language.get("Player_CheckpointReached"));
 			}
 
-			this.gworld.dSigns.remove(this);
+			remove();
 		}
 	}
 

--- a/src/com/dre/dungeonsxl/signs/SIGNEnd.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNEnd.java
@@ -2,7 +2,11 @@ package com.dre.dungeonsxl.signs;
 
 import org.bukkit.ChatColor;
 import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
+
+import com.dre.dungeonsxl.DPlayer;
 import com.dre.dungeonsxl.game.GameWorld;
+import com.dre.dungeonsxl.trigger.InteractTrigger;
 
 public class SIGNEnd extends DSign {
 
@@ -23,12 +27,38 @@ public class SIGNEnd extends DSign {
 
 	@Override
 	public void onInit() {
-		gworld.blocksEnd.add(sign.getBlock());
-		sign.setLine(0, ChatColor.DARK_BLUE + "############");
-		sign.setLine(1, ChatColor.DARK_GREEN + "End");
-		sign.setLine(2, "");
-		sign.setLine(3, ChatColor.DARK_BLUE + "############");
-		sign.update();
+		if (triggers.isEmpty()) {
+			InteractTrigger trigger = InteractTrigger.getOrCreate(0, sign.getBlock(), gworld);
+			if (trigger != null) {
+				trigger.addListener(this);
+				this.triggers.add(trigger);
+			}
+			sign.setLine(0, ChatColor.DARK_BLUE + "############");
+			sign.setLine(1, ChatColor.DARK_GREEN + "End");
+			sign.setLine(2, "");
+			sign.setLine(3, ChatColor.DARK_BLUE + "############");
+			sign.update();
+		} else {
+			sign.getBlock().setTypeId(0);
+		}
+	}
+
+	@Override
+	public boolean onPlayerTrigger(Player player) {
+		DPlayer dplayer = DPlayer.get(player);
+		if (dplayer != null) {
+			if (!dplayer.isFinished) {
+				dplayer.finish();
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public void onTrigger() {
+		for (DPlayer dplayer : DPlayer.players) {
+			dplayer.finish();
+		}
 	}
 
 	@Override

--- a/src/com/dre/dungeonsxl/signs/SIGNInteract.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNInteract.java
@@ -15,7 +15,7 @@ import com.dre.dungeonsxl.trigger.InteractTrigger;
 public class SIGNInteract extends DSign {
 	public static String name = "Interact";
 	public String buildPermissions = "dxl.sign.trigger";
-	public boolean onDungeonInit = false;
+	public boolean onDungeonInit = true;
 
 	public SIGNInteract(Sign sign, GameWorld gworld) {
 		super(sign, gworld);
@@ -47,7 +47,7 @@ public class SIGNInteract extends DSign {
 			}
 		} else {
 			id = p.parseInt(sign.getLine(1));
-			if (used.contains(id)) {
+			if (id == 0 || used.contains(id)) {
 				return false;
 			} else {
 				return true;

--- a/src/com/dre/dungeonsxl/signs/SIGNInteract.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNInteract.java
@@ -1,0 +1,102 @@
+package com.dre.dungeonsxl.signs;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.bukkit.block.Sign;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.ChatColor;
+
+import com.dre.dungeonsxl.game.GameWorld;
+import com.dre.dungeonsxl.EditWorld;
+import com.dre.dungeonsxl.trigger.InteractTrigger;
+
+public class SIGNInteract extends DSign {
+	public static String name = "Interact";
+	public String buildPermissions = "dxl.sign.trigger";
+	public boolean onDungeonInit = false;
+
+	public SIGNInteract(Sign sign, GameWorld gworld) {
+		super(sign, gworld);
+	}
+
+	@Override
+	public boolean check() {
+		Set<Integer> used = new HashSet<Integer>();
+		for (Block block : EditWorld.get(sign.getLocation().getWorld()).sign) {
+			if (block != null) {
+				if (!block.getChunk().isLoaded()) {
+					block.getChunk().load();
+				}
+				if (block.getState() instanceof Sign) {
+					Sign rsign = (Sign) block.getState();
+					if (rsign.getLine(0).equalsIgnoreCase("[" + name + "]")) {
+						used.add(p.parseInt(rsign.getLine(1)));
+					}
+				}
+			}
+		}
+
+		int id = 1;
+		if (sign.getLine(1).equalsIgnoreCase("")) {
+			if (used.size() != 0) {
+				while (used.contains(id)) {
+					id++;
+				}
+			}
+		} else {
+			id = p.parseInt(sign.getLine(1));
+			if (used.contains(id)) {
+				return false;
+			} else {
+				return true;
+			}
+		}
+
+		sign.setLine(1, id + "");
+		p.getServer().getScheduler().scheduleSyncDelayedTask(p, new UpdateTask(), 2);
+		return true;
+	}
+
+	@Override
+	public void onInit() {
+		InteractTrigger trigger = InteractTrigger.getOrCreate(p.parseInt(sign.getLine(1)), sign.getBlock(), gworld);
+		if (trigger != null) {
+			trigger.addListener(this);
+			this.triggers.add(trigger);
+		}
+
+		sign.setLine(0, ChatColor.DARK_BLUE + "############");
+		sign.setLine(1, ChatColor.GREEN + sign.getLine(2));
+		sign.setLine(2, ChatColor.GREEN + sign.getLine(3));
+		sign.setLine(3, ChatColor.DARK_BLUE + "############");
+		sign.update();
+	}
+
+	@Override
+	public boolean onPlayerTrigger(Player player) {
+		return true;
+	}
+
+	@Override
+	public String getPermissions() {
+		return buildPermissions;
+	}
+
+	@Override
+	public boolean isOnDungeonInit() {
+		return onDungeonInit;
+	}
+
+	public class UpdateTask implements Runnable {
+
+		public UpdateTask() {
+		}
+
+		@Override
+		public void run() {
+			sign.update();
+		}
+	}
+}

--- a/src/com/dre/dungeonsxl/signs/SIGNLeave.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNLeave.java
@@ -2,7 +2,11 @@ package com.dre.dungeonsxl.signs;
 
 import org.bukkit.ChatColor;
 import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
+
+import com.dre.dungeonsxl.DPlayer;
 import com.dre.dungeonsxl.game.GameWorld;
+import com.dre.dungeonsxl.trigger.InteractTrigger;
 
 public class SIGNLeave extends DSign {
 
@@ -23,12 +27,36 @@ public class SIGNLeave extends DSign {
 
 	@Override
 	public void onInit() {
-		gworld.blocksLeave.add(sign.getBlock());
-		sign.setLine(0, ChatColor.BLUE + "############");
-		sign.setLine(1, ChatColor.DARK_GREEN + "Leave");
-		sign.setLine(2, "");
-		sign.setLine(3, ChatColor.BLUE + "############");
-		sign.update();
+		if (triggers.isEmpty()) {
+			InteractTrigger trigger = InteractTrigger.getOrCreate(0, sign.getBlock(), gworld);
+			if (trigger != null) {
+				trigger.addListener(this);
+				this.triggers.add(trigger);
+			}
+			sign.setLine(0, ChatColor.DARK_BLUE + "############");
+			sign.setLine(1, ChatColor.DARK_GREEN + "Leave");
+			sign.setLine(2, "");
+			sign.setLine(3, ChatColor.DARK_BLUE + "############");
+			sign.update();
+		} else {
+			sign.getBlock().setTypeId(0);
+		}
+	}
+
+	@Override
+	public boolean onPlayerTrigger(Player player) {
+		DPlayer dplayer = DPlayer.get(player);
+		if (dplayer != null) {
+			dplayer.leave();
+		}
+		return true;
+	}
+
+	@Override
+	public void onTrigger() {
+		for (DPlayer dplayer : DPlayer.players) {
+			dplayer.leave();
+		}
 	}
 
 	@Override

--- a/src/com/dre/dungeonsxl/signs/SIGNMob.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNMob.java
@@ -140,7 +140,7 @@ public class SIGNMob extends DSign {
 							amount--;
 						} else {
 							killTask();
-							sign.gworld.dSigns.remove(sign);
+							sign.remove();
 						}
 					}
 

--- a/src/com/dre/dungeonsxl/signs/SIGNMsg.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNMsg.java
@@ -46,20 +46,26 @@ public class SIGNMsg extends DSign {
 	}
 
 	@Override
+	public boolean onPlayerTrigger(Player player) {
+		if (initialized) {
+			if (!done.contains(player)) {
+				p.msg(player, msg);
+				done.add(player);
+			}
+			if (done.size() >= gworld.world.getPlayers().size()) {
+				remove();
+			}
+		}
+		return true;
+	}
+
+	@Override
 	public void onTrigger() {
 		if (initialized) {
 			for (Player player : gworld.world.getPlayers()) {
-				if (!done.contains(player)) {
-					if (!isDistanceTrigger() || player.getLocation().distance(sign.getLocation()) < getDtDistance()) {
-						p.msg(player, msg);
-						done.add(player);
-					}
-				}
+				p.msg(player, msg);
 			}
-
-			if (done.size() >= gworld.world.getPlayers().size()) {
-				this.gworld.dSigns.remove(this);
-			}
+			remove();
 		}
 	}
 

--- a/src/com/dre/dungeonsxl/signs/SIGNReady.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNReady.java
@@ -2,7 +2,12 @@ package com.dre.dungeonsxl.signs;
 
 import org.bukkit.ChatColor;
 import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
+
+import com.dre.dungeonsxl.DPlayer;
 import com.dre.dungeonsxl.game.GameWorld;
+import com.dre.dungeonsxl.trigger.InteractTrigger;
+import com.dre.dungeonsxl.P;
 
 public class SIGNReady extends DSign {
 
@@ -23,12 +28,47 @@ public class SIGNReady extends DSign {
 
 	@Override
 	public void onInit() {
-		gworld.blocksReady.add(sign.getBlock());
-		sign.setLine(0, ChatColor.BLUE + "############");
-		sign.setLine(1, ChatColor.DARK_GREEN + "Ready");
-		sign.setLine(2, "");
-		sign.setLine(3, ChatColor.BLUE + "############");
-		sign.update();
+		if (triggers.isEmpty()) {
+			InteractTrigger trigger = InteractTrigger.getOrCreate(0, sign.getBlock(), gworld);
+			if (trigger != null) {
+				trigger.addListener(this);
+				this.triggers.add(trigger);
+			}
+			sign.setLine(0, ChatColor.DARK_BLUE + "############");
+			sign.setLine(1, ChatColor.DARK_GREEN + "Ready");
+			sign.setLine(2, "");
+			sign.setLine(3, ChatColor.DARK_BLUE + "############");
+			sign.update();
+		} else {
+			sign.getBlock().setTypeId(0);
+		}
+	}
+
+	@Override
+	public boolean onPlayerTrigger(Player player) {
+		ready(DPlayer.get(player));
+		return true;
+	}
+
+	@Override
+	public void onTrigger() {
+		for (DPlayer dplayer : DPlayer.players) {
+			ready(dplayer);
+		}
+	}
+
+	private void ready(DPlayer dplayer) {
+		if (dplayer != null) {
+			if (!dplayer.isReady) {
+				if (gworld.signClass.isEmpty() || dplayer.dclass != null) {
+					dplayer.ready();
+					P.p.msg(dplayer.player, p.language.get("Player_Ready"));
+					return;
+				} else {
+					P.p.msg(dplayer.player, p.language.get("Error_Ready"));
+				}
+			}
+		}
 	}
 
 	@Override

--- a/src/com/dre/dungeonsxl/signs/SIGNRedstone.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNRedstone.java
@@ -4,6 +4,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 
 import com.dre.dungeonsxl.game.GameWorld;
+import com.dre.dungeonsxl.P;
 
 public class SIGNRedstone extends DSign {
 
@@ -14,7 +15,13 @@ public class SIGNRedstone extends DSign {
 	// Variables
 	private boolean initialized;
 	private boolean active;
+	private int enableTaskId = -1;
+	private int disableTaskId = -1;
 	private Block block;
+	private long delay = 0;
+	private long offDelay = 0;
+	private int repeat = 1;
+	private int repeatsToDo = 1;
 
 	public SIGNRedstone(Sign sign, GameWorld gworld) {
 		super(sign, gworld);
@@ -22,12 +29,38 @@ public class SIGNRedstone extends DSign {
 
 	@Override
 	public boolean check() {
-
 		return true;
 	}
 
 	@Override
 	public void onInit() {
+		int line1 = 0;
+		int line11 = 0;
+		if (!sign.getLine(1).equals("")) {
+			String line[] = sign.getLine(1).split(",");
+			line1 = P.p.parseInt(line[0]);
+			if (line.length > 1) {
+				line11 = P.p.parseInt(line[1]);
+			}
+		}
+
+		int line2 = 1;
+		if (!sign.getLine(2).equals("")) {
+			line2 = P.p.parseInt(sign.getLine(2));
+		}
+
+		if (line1 > 0) {
+			delay = (long) line1 * 2;
+			if (line11 > 0) {
+				offDelay = (long) line11 * 2;
+			} else {
+				offDelay = delay;
+			}
+			if (line2 >= 0) {
+				repeat = line2;
+			}
+		}
+
 		this.block = sign.getBlock();
 		this.block.setTypeId(0);
 
@@ -37,7 +70,15 @@ public class SIGNRedstone extends DSign {
 	@Override
 	public void onTrigger() {
 		if (initialized && !active) {
-			block.setTypeId(152);
+			if (delay > 0) {
+				enableTaskId = P.p.getServer().getScheduler().scheduleSyncRepeatingTask(P.p, new DelayedPower(true), delay, delay + offDelay);
+				if (repeat != 1) {
+					repeatsToDo = repeat;
+					disableTaskId = P.p.getServer().getScheduler().scheduleSyncRepeatingTask(P.p, new DelayedPower(false), delay + offDelay, delay + offDelay);
+				}
+			} else {
+				power();
+			}
 			active = true;
 		}
 	}
@@ -45,8 +86,30 @@ public class SIGNRedstone extends DSign {
 	@Override
 	public void onDisable() {
 		if (initialized && active) {
-			block.setTypeId(0);
+			unpower();
+
+			disableTask(enableTaskId);
+			disableTask(disableTaskId);
+			enableTaskId = -1;
+			disableTaskId = -1;
+
 			active = false;
+		}
+	}
+
+	public void power() {
+		block.setTypeId(152);
+	}
+
+	public void unpower() {
+		block.setTypeId(0);
+	}
+
+	public void disableTask(int taskId) {
+		if (taskId != -1) {
+			if (P.p.getServer().getScheduler().isCurrentlyRunning(taskId) || P.p.getServer().getScheduler().isQueued(taskId)) {
+				P.p.getServer().getScheduler().cancelTask(taskId);
+			}
 		}
 	}
 
@@ -58,5 +121,31 @@ public class SIGNRedstone extends DSign {
 	@Override
 	public boolean isOnDungeonInit() {
 		return onDungeonInit;
+	}
+
+	public class DelayedPower implements Runnable {
+		private final boolean enable;
+
+		public DelayedPower(boolean enable) {
+			this.enable = enable;
+		}
+
+		@Override
+		public void run() {
+			if (enable) {
+				power();
+				if (repeatsToDo == 1) {
+					disableTask(enableTaskId);
+					enableTaskId = -1;
+				}
+			} else {
+				unpower();
+				if (repeatsToDo == 1) {
+					disableTask(disableTaskId);
+					disableTaskId = -1;
+				}
+				repeatsToDo--;
+			}
+		}
 	}
 }

--- a/src/com/dre/dungeonsxl/signs/SIGNRedstone.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNRedstone.java
@@ -132,6 +132,11 @@ public class SIGNRedstone extends DSign {
 
 		@Override
 		public void run() {
+			if (GameWorld.get(block.getWorld()) == null) {
+				disableTask(enableTaskId);
+				disableTask(disableTaskId);
+				return;
+			}
 			if (enable) {
 				power();
 				if (repeatsToDo == 1) {

--- a/src/com/dre/dungeonsxl/signs/SIGNSoundMsg.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNSoundMsg.java
@@ -55,22 +55,36 @@ public class SIGNSoundMsg extends DSign {
 		if (initialized) {
 			if (P.p.isSpoutEnabled) {
 				for (Player player : gworld.world.getPlayers()) {
-					if (!done.contains(player)) {
-						if (!isDistanceTrigger() || player.getLocation().distance(sign.getLocation()) < getDtDistance()) {
-							done.add(player);
-							SpoutPlayer sPlayer = Spout.getServer().getPlayer(player.getName());
-							if (sPlayer.isSpoutCraftEnabled()) {
-								SpoutManager.getSoundManager().playCustomMusic(P.p, sPlayer, this.msg, false, this.sign.getLocation());
-							}
-						}
+					SpoutPlayer sPlayer = Spout.getServer().getPlayer(player.getName());
+					if (sPlayer.isSpoutCraftEnabled()) {
+						SpoutManager.getSoundManager().playCustomMusic(P.p, sPlayer, this.msg, false, this.sign.getLocation());
 					}
 				}
 			}
+			remove();
+		}
+	}
+
+	@Override
+	public boolean onPlayerTrigger(Player player) {
+		if (initialized) {
+			if (P.p.isSpoutEnabled) {
+				if (!done.contains(player)) {
+					done.add(player);
+					SpoutPlayer sPlayer = Spout.getServer().getPlayer(player.getName());
+					if (sPlayer.isSpoutCraftEnabled()) {
+						SpoutManager.getSoundManager().playCustomMusic(P.p, sPlayer, this.msg, false, this.sign.getLocation());
+					}
+				}
+			} else {
+				remove();
+			}
 
 			if (done.size() >= gworld.world.getPlayers().size()) {
-				this.gworld.dSigns.remove(this);
+				remove();
 			}
 		}
+		return true;
 	}
 
 	@Override

--- a/src/com/dre/dungeonsxl/signs/SIGNTrigger.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNTrigger.java
@@ -13,7 +13,7 @@ import com.dre.dungeonsxl.trigger.SignTrigger;
 public class SIGNTrigger extends DSign {
 	public static String name = "Trigger";
 	public String buildPermissions = "dxl.sign.trigger";
-	public boolean onDungeonInit = false;
+	public boolean onDungeonInit = true;
 
 	// Variables
 	private int triggerId;

--- a/src/com/dre/dungeonsxl/signs/SIGNTrigger.java
+++ b/src/com/dre/dungeonsxl/signs/SIGNTrigger.java
@@ -8,12 +8,12 @@ import org.bukkit.block.Block;
 
 import com.dre.dungeonsxl.game.GameWorld;
 import com.dre.dungeonsxl.EditWorld;
+import com.dre.dungeonsxl.trigger.SignTrigger;
 
 public class SIGNTrigger extends DSign {
 	public static String name = "Trigger";
 	public String buildPermissions = "dxl.sign.trigger";
 	public boolean onDungeonInit = false;
-	public static Set<Integer> used = new HashSet<Integer>();
 
 	// Variables
 	private int triggerId;
@@ -25,11 +25,14 @@ public class SIGNTrigger extends DSign {
 
 	@Override
 	public boolean check() {
-		used.clear();
+		Set<Integer> used = new HashSet<Integer>();
 		for (Block block : EditWorld.get(sign.getLocation().getWorld()).sign) {
-			if (block.getState() instanceof Sign) {
-				Sign rsign = (Sign) block.getState();
-				if (rsign != null) {
+			if (block != null) {
+				if (!block.getChunk().isLoaded()) {
+					block.getChunk().load();
+				}
+				if (block.getState() instanceof Sign) {
+					Sign rsign = (Sign) block.getState();
 					if (rsign.getLine(0).equalsIgnoreCase("[" + name + "]")) {
 						used.add(p.parseInt(rsign.getLine(1)));
 					}
@@ -69,14 +72,9 @@ public class SIGNTrigger extends DSign {
 	@Override
 	public void onTrigger() {
 		if (initialized) {
-			for (DSign dsign : this.gworld.dSigns) {
-				if (dsign != null) {
-					if (dsign.isSignTrigger()) {
-						if (triggerId == dsign.getStId()) {
-							dsign.onUpdate(1, true);
-						}
-					}
-				}
+			SignTrigger trigger = SignTrigger.get(triggerId, gworld);
+			if (trigger != null) {
+				trigger.onTrigger(true);
 			}
 		}
 	}
@@ -84,14 +82,9 @@ public class SIGNTrigger extends DSign {
 	@Override
 	public void onDisable() {
 		if (initialized) {
-			for (DSign dsign : this.gworld.dSigns) {
-				if (dsign != null) {
-					if (dsign.isSignTrigger()) {
-						if (triggerId == dsign.getStId()) {
-							dsign.onUpdate(1, false);
-						}
-					}
-				}
+			SignTrigger trigger = SignTrigger.get(triggerId, gworld);
+			if (trigger != null) {
+				trigger.onTrigger(false);
 			}
 		}
 	}

--- a/src/com/dre/dungeonsxl/trigger/DistanceTrigger.java
+++ b/src/com/dre/dungeonsxl/trigger/DistanceTrigger.java
@@ -1,0 +1,75 @@
+package com.dre.dungeonsxl.trigger;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.ArrayList;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import com.dre.dungeonsxl.game.GameWorld;
+
+public class DistanceTrigger extends Trigger {
+
+	private static Map<GameWorld, ArrayList<DistanceTrigger>> triggers = new HashMap<GameWorld, ArrayList<DistanceTrigger>>();
+
+	private int distance = 5;
+	private Location loc;
+
+
+	public DistanceTrigger(int distance, Location loc) {
+		if (distance >= 0) {
+			this.distance = distance;
+		}
+		this.loc = loc;
+	}
+
+	public DistanceTrigger(Location loc) {
+		this.loc = loc;
+	}
+
+	public void onTrigger(Player player) {
+		triggered = true;
+		this.player = player;
+		updateDSigns();
+
+	}
+
+	public void register(GameWorld gworld) {
+		if (!hasTriggers(gworld)) {
+			ArrayList<DistanceTrigger> list = new ArrayList<DistanceTrigger>();
+			list.add(this);
+			triggers.put(gworld, list);
+		} else {
+			triggers.get(gworld).add(this);
+		}
+	}
+
+	public void unregister(GameWorld gworld) {
+		if (hasTriggers(gworld)) {
+			triggers.get(gworld).remove(this);
+		}
+	}
+
+	public static void triggerAllInDistance(Player player, GameWorld gworld) {
+		if (hasTriggers(gworld)) {
+			for (DistanceTrigger trigger : getTriggersArray(gworld)) {
+				if (player.getLocation().distance(trigger.loc) < trigger.distance) {
+					trigger.onTrigger(player);
+				}
+			}
+		}
+	}
+
+	public static boolean hasTriggers(GameWorld gworld) {
+		return !triggers.isEmpty() && triggers.containsKey(gworld);
+	}
+
+	public static ArrayList<DistanceTrigger> getTriggers(GameWorld gworld) {
+		return triggers.get(gworld);
+	}
+
+	public static DistanceTrigger[] getTriggersArray(GameWorld gworld) {
+		return getTriggers(gworld).toArray(new DistanceTrigger[getTriggers(gworld).size()]);
+	}
+
+}

--- a/src/com/dre/dungeonsxl/trigger/InteractTrigger.java
+++ b/src/com/dre/dungeonsxl/trigger/InteractTrigger.java
@@ -44,6 +44,9 @@ public class InteractTrigger extends Trigger {
 	}
 
 	public static InteractTrigger getOrCreate(int id, GameWorld gworld) {
+		if (id == 0) {
+			return null;
+		}
 		InteractTrigger trigger = get(id, gworld);
 		if (trigger != null) {
 			return trigger;

--- a/src/com/dre/dungeonsxl/trigger/InteractTrigger.java
+++ b/src/com/dre/dungeonsxl/trigger/InteractTrigger.java
@@ -1,0 +1,91 @@
+package com.dre.dungeonsxl.trigger;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.ArrayList;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import com.dre.dungeonsxl.game.GameWorld;
+
+public class InteractTrigger extends Trigger {
+
+	private static Map<GameWorld, ArrayList<InteractTrigger>> triggers = new HashMap<GameWorld, ArrayList<InteractTrigger>>();
+
+	private int interactId;
+	private Block interactBlock;
+
+
+	public InteractTrigger(int id, Block block) {
+		this.interactId = id;
+		this.interactBlock = block;
+	}
+
+	public void onTrigger(Player player) {
+		triggered = true;
+		this.player = player;
+		updateDSigns();
+	}
+
+	public void register(GameWorld gworld) {
+		if (!hasTriggers(gworld)) {
+			ArrayList<InteractTrigger> list = new ArrayList<InteractTrigger>();
+			list.add(this);
+			triggers.put(gworld, list);
+		} else {
+			triggers.get(gworld).add(this);
+		}
+	}
+
+	public void unregister(GameWorld gworld) {
+		if (hasTriggers(gworld)) {
+			triggers.get(gworld).remove(this);
+		}
+	}
+
+	public static InteractTrigger getOrCreate(int id, GameWorld gworld) {
+		InteractTrigger trigger = get(id, gworld);
+		if (trigger != null) {
+			return trigger;
+		}
+		return new InteractTrigger(id, null);
+	}
+
+	public static InteractTrigger getOrCreate(int id, Block block, GameWorld gworld) {
+		InteractTrigger trigger = get(id, gworld);
+		if (trigger != null) {
+			trigger.interactBlock = block;
+			return trigger;
+		}
+		return new InteractTrigger(id, block);
+	}
+
+	public static InteractTrigger get(Block block, GameWorld gworld) {
+		if (hasTriggers(gworld)) {
+			for (InteractTrigger trigger : triggers.get(gworld)) {
+				if (trigger.interactBlock != null) {
+					if (trigger.interactBlock.equals(block)) {
+						return trigger;
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	public static InteractTrigger get(int id, GameWorld gworld) {
+		if (hasTriggers(gworld)) {
+			for (InteractTrigger trigger : triggers.get(gworld)) {
+				if (trigger.interactId == id) {
+					return trigger;
+				}
+			}
+		}
+		return null;
+	}
+
+	public static boolean hasTriggers(GameWorld gworld) {
+		return !triggers.isEmpty() && triggers.containsKey(gworld);
+	}
+
+}

--- a/src/com/dre/dungeonsxl/trigger/MobTrigger.java
+++ b/src/com/dre/dungeonsxl/trigger/MobTrigger.java
@@ -1,0 +1,63 @@
+package com.dre.dungeonsxl.trigger;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.ArrayList;
+import com.dre.dungeonsxl.game.GameWorld;
+
+
+public class MobTrigger extends Trigger {
+
+	private static Map<GameWorld, ArrayList<MobTrigger>> triggers = new HashMap<GameWorld, ArrayList<MobTrigger>>();
+
+	private String name;
+
+	public MobTrigger(String name) {
+		this.name = name;
+	}
+
+	public void onTrigger() {
+		triggered = true;
+		updateDSigns();
+	}
+
+	public void register(GameWorld gworld) {
+		if (!hasTriggers(gworld)) {
+			ArrayList<MobTrigger> list = new ArrayList<MobTrigger>();
+			list.add(this);
+			triggers.put(gworld, list);
+		} else {
+			triggers.get(gworld).add(this);
+		}
+	}
+
+	public void unregister(GameWorld gworld) {
+		if (hasTriggers(gworld)) {
+			triggers.get(gworld).remove(this);
+		}
+	}
+
+	public static MobTrigger getOrCreate(String name, GameWorld gworld) {
+		MobTrigger trigger = get(name, gworld);
+		if (trigger != null) {
+			return trigger;
+		}
+		return new MobTrigger(name);
+	}
+
+	public static MobTrigger get(String name, GameWorld gworld) {
+		if (hasTriggers(gworld)) {
+			for (MobTrigger trigger : triggers.get(gworld)) {
+				if (trigger.name.equalsIgnoreCase(name)) {
+					return trigger;
+				}
+			}
+		}
+		return null;
+	}
+
+	public static boolean hasTriggers(GameWorld gworld) {
+		return !triggers.isEmpty() && triggers.containsKey(gworld);
+	}
+
+}

--- a/src/com/dre/dungeonsxl/trigger/RedstoneTrigger.java
+++ b/src/com/dre/dungeonsxl/trigger/RedstoneTrigger.java
@@ -1,0 +1,109 @@
+package com.dre.dungeonsxl.trigger;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.ArrayList;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.Material;
+import org.bukkit.block.Sign;
+
+import com.dre.dungeonsxl.game.GameWorld;
+
+
+public class RedstoneTrigger extends Trigger {
+
+	private static Map<GameWorld, ArrayList<RedstoneTrigger>> triggers = new HashMap<GameWorld, ArrayList<RedstoneTrigger>>();
+
+	private Block rtBlock;
+
+	public RedstoneTrigger(Block block) {
+		this.rtBlock = block;
+	}
+
+	public void onTrigger() {
+		if (rtBlock.isBlockPowered()) {
+			if (!triggered) {
+				triggered = true;
+				updateDSigns();
+			}
+		} else {
+			if (triggered) {
+				triggered = false;
+				updateDSigns();
+			}
+		}
+	}
+
+	public void register(GameWorld gworld) {
+		if (!hasTriggers(gworld)) {
+			ArrayList<RedstoneTrigger> list = new ArrayList<RedstoneTrigger>();
+			list.add(this);
+			triggers.put(gworld, list);
+		} else {
+			triggers.get(gworld).add(this);
+		}
+	}
+
+	public void unregister(GameWorld gworld) {
+		if (hasTriggers(gworld)) {
+			triggers.get(gworld).remove(this);
+		}
+	}
+
+	public static RedstoneTrigger getOrCreate(Sign sign, GameWorld gworld) {
+		Block rtBlock = null;
+		if (sign.getBlock().getType() == Material.WALL_SIGN) {
+			switch (sign.getData().getData()) {
+			case 5:
+				rtBlock = sign.getBlock().getRelative(BlockFace.WEST);
+				break;
+			case 4:
+				rtBlock = sign.getBlock().getRelative(BlockFace.EAST);
+				break;
+			case 3:
+				rtBlock = sign.getBlock().getRelative(BlockFace.NORTH);
+				break;
+			case 2:
+				rtBlock = sign.getBlock().getRelative(BlockFace.SOUTH);
+				break;
+			}
+		} else {
+			rtBlock = sign.getBlock().getRelative(BlockFace.DOWN);
+		}
+
+		if (rtBlock != null) {
+			if (hasTriggers(gworld)) {
+				for (RedstoneTrigger trigger : getTriggers(gworld)) {
+					if (trigger.rtBlock.equals(rtBlock)) {
+						return trigger;
+					}
+				}
+			}
+			return new RedstoneTrigger(rtBlock);
+		}
+		return null;
+	}
+
+	public static void updateAll(GameWorld gworld) {
+		if (hasTriggers(gworld)) {
+			for (RedstoneTrigger trigger : getTriggersArray(gworld)) {
+				trigger.onTrigger();
+			}
+		}
+	}
+
+	public static boolean hasTriggers(GameWorld gworld) {
+		return !triggers.isEmpty() && triggers.containsKey(gworld);
+	}
+
+	public static ArrayList<RedstoneTrigger> getTriggers(GameWorld gworld) {
+		return triggers.get(gworld);
+	}
+
+	public static RedstoneTrigger[] getTriggersArray(GameWorld gworld) {
+		return getTriggers(gworld).toArray(new RedstoneTrigger[getTriggers(gworld).size()]);
+	}
+
+}

--- a/src/com/dre/dungeonsxl/trigger/SignTrigger.java
+++ b/src/com/dre/dungeonsxl/trigger/SignTrigger.java
@@ -1,0 +1,65 @@
+package com.dre.dungeonsxl.trigger;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.ArrayList;
+import com.dre.dungeonsxl.game.GameWorld;
+
+
+public class SignTrigger extends Trigger {
+
+	private static Map<GameWorld, ArrayList<SignTrigger>> triggers = new HashMap<GameWorld, ArrayList<SignTrigger>>();
+
+	private int stId;
+
+	public SignTrigger(int stId) {
+		this.stId = stId;
+	}
+
+	public void onTrigger(boolean enable) {
+		if (enable != triggered) {
+			triggered = enable;
+			updateDSigns();
+		}
+	}
+
+	public void register(GameWorld gworld) {
+		if (!hasTriggers(gworld)) {
+			ArrayList<SignTrigger> list = new ArrayList<SignTrigger>();
+			list.add(this);
+			triggers.put(gworld, list);
+		} else {
+			triggers.get(gworld).add(this);
+		}
+	}
+
+	public void unregister(GameWorld gworld) {
+		if (hasTriggers(gworld)) {
+			triggers.get(gworld).remove(this);
+		}
+	}
+
+	public static SignTrigger getOrCreate(int id, GameWorld gworld) {
+		SignTrigger trigger = get(id, gworld);
+		if (trigger != null) {
+			return trigger;
+		}
+		return new SignTrigger(id);
+	}
+
+	public static SignTrigger get(int id, GameWorld gworld) {
+		if (hasTriggers(gworld)) {
+			for (SignTrigger trigger : triggers.get(gworld)) {
+				if (trigger.stId == id) {
+					return trigger;
+				}
+			}
+		}
+		return null;
+	}
+
+	public static boolean hasTriggers(GameWorld gworld) {
+		return !triggers.isEmpty() && triggers.containsKey(gworld);
+	}
+
+}

--- a/src/com/dre/dungeonsxl/trigger/Trigger.java
+++ b/src/com/dre/dungeonsxl/trigger/Trigger.java
@@ -57,6 +57,12 @@ public abstract class Trigger {
 					trigger = MobTrigger.getOrCreate(splitted[1], dsign.getGameWorld());
 				}
 
+			} else if (splitted[0].equalsIgnoreCase("U")) {
+
+				if (splitted.length > 1) {
+					trigger = UseItemTrigger.getOrCreate(splitted[1], dsign.getGameWorld());
+				}
+
 			}
 		}
 		return trigger;

--- a/src/com/dre/dungeonsxl/trigger/Trigger.java
+++ b/src/com/dre/dungeonsxl/trigger/Trigger.java
@@ -1,0 +1,73 @@
+package com.dre.dungeonsxl.trigger;
+
+import java.util.Set;
+import java.util.HashSet;
+
+import org.bukkit.entity.Player;
+
+import com.dre.dungeonsxl.P;
+import com.dre.dungeonsxl.signs.DSign;
+import com.dre.dungeonsxl.game.GameWorld;
+
+public abstract class Trigger {
+
+	protected Set<DSign> dsigns = new HashSet<DSign>();
+	public boolean triggered = false;
+	public Player player = null; // Holds Player for Player specific Triggers
+
+	public Trigger() {
+
+	}
+
+	public abstract void register(GameWorld gworld);
+
+	public abstract void unregister(GameWorld gworld);
+
+	public static Trigger getOrCreate(String[] splitted, DSign dsign) {
+		Trigger trigger = null;
+
+		if (splitted.length > 0) {
+			if (splitted[0].equalsIgnoreCase("R")) {
+
+				trigger = RedstoneTrigger.getOrCreate(dsign.getSign(), dsign.getGameWorld());
+
+			} else if (splitted[0].equalsIgnoreCase("D")) {
+
+				if (splitted.length > 1) {
+					trigger = new DistanceTrigger(P.p.parseInt(splitted[1]), dsign.getSign().getLocation());
+				} else {
+					trigger = new DistanceTrigger(dsign.getSign().getLocation());
+				}
+
+			} else if (splitted[0].equalsIgnoreCase("T")) {
+
+				if (splitted.length > 1) {
+					trigger = SignTrigger.getOrCreate(P.p.parseInt(splitted[1]), dsign.getGameWorld());
+				}
+
+			}
+		}
+		return trigger;
+	}
+
+	public void addListener(DSign dsign) {
+		if (dsigns.isEmpty()) {
+			register(dsign.getGameWorld());
+		}
+		dsigns.add(dsign);
+	}
+
+	public void removeListener(DSign dsign) {
+		dsigns.remove(dsign);
+		if (dsigns.isEmpty()) {
+			unregister(dsign.getGameWorld());
+		}
+	}
+
+	public void updateDSigns() {
+		for (DSign dsign : dsigns.toArray(new DSign[dsigns.size()])) {
+			dsign.onUpdate();
+		}
+	}
+
+}

--- a/src/com/dre/dungeonsxl/trigger/Trigger.java
+++ b/src/com/dre/dungeonsxl/trigger/Trigger.java
@@ -23,47 +23,45 @@ public abstract class Trigger {
 
 	public abstract void unregister(GameWorld gworld);
 
-	public static Trigger getOrCreate(String[] splitted, DSign dsign) {
+	public static Trigger getOrCreate(String type, String value, DSign dsign) {
 		Trigger trigger = null;
 
-		if (splitted.length > 0) {
-			if (splitted[0].equalsIgnoreCase("R")) {
+		if (type.equalsIgnoreCase("R")) {
 
-				trigger = RedstoneTrigger.getOrCreate(dsign.getSign(), dsign.getGameWorld());
+			trigger = RedstoneTrigger.getOrCreate(dsign.getSign(), dsign.getGameWorld());
 
-			} else if (splitted[0].equalsIgnoreCase("D")) {
+		} else if (type.equalsIgnoreCase("D")) {
 
-				if (splitted.length > 1) {
-					trigger = new DistanceTrigger(P.p.parseInt(splitted[1]), dsign.getSign().getLocation());
-				} else {
-					trigger = new DistanceTrigger(dsign.getSign().getLocation());
-				}
-
-			} else if (splitted[0].equalsIgnoreCase("T")) {
-
-				if (splitted.length > 1) {
-					trigger = SignTrigger.getOrCreate(P.p.parseInt(splitted[1]), dsign.getGameWorld());
-				}
-
-			} else if (splitted[0].equalsIgnoreCase("I")) {
-
-				if (splitted.length > 1) {
-					trigger = InteractTrigger.getOrCreate(P.p.parseInt(splitted[1]), dsign.getGameWorld());
-				}
-
-			} else if (splitted[0].equalsIgnoreCase("M")) {
-
-				if (splitted.length > 1) {
-					trigger = MobTrigger.getOrCreate(splitted[1], dsign.getGameWorld());
-				}
-
-			} else if (splitted[0].equalsIgnoreCase("U")) {
-
-				if (splitted.length > 1) {
-					trigger = UseItemTrigger.getOrCreate(splitted[1], dsign.getGameWorld());
-				}
-
+			if (value != null) {
+				trigger = new DistanceTrigger(P.p.parseInt(value), dsign.getSign().getLocation());
+			} else {
+				trigger = new DistanceTrigger(dsign.getSign().getLocation());
 			}
+
+		} else if (type.equalsIgnoreCase("T")) {
+
+			if (value != null) {
+				trigger = SignTrigger.getOrCreate(P.p.parseInt(value), dsign.getGameWorld());
+			}
+
+		} else if (type.equalsIgnoreCase("I")) {
+
+			if (value != null) {
+				trigger = InteractTrigger.getOrCreate(P.p.parseInt(value), dsign.getGameWorld());
+			}
+
+		} else if (type.equalsIgnoreCase("M")) {
+
+			if (value != null) {
+				trigger = MobTrigger.getOrCreate(value, dsign.getGameWorld());
+			}
+
+		} else if (type.equalsIgnoreCase("U")) {
+
+			if (value != null) {
+				trigger = UseItemTrigger.getOrCreate(value, dsign.getGameWorld());
+			}
+
 		}
 		return trigger;
 	}

--- a/src/com/dre/dungeonsxl/trigger/Trigger.java
+++ b/src/com/dre/dungeonsxl/trigger/Trigger.java
@@ -51,6 +51,12 @@ public abstract class Trigger {
 					trigger = InteractTrigger.getOrCreate(P.p.parseInt(splitted[1]), dsign.getGameWorld());
 				}
 
+			} else if (splitted[0].equalsIgnoreCase("M")) {
+
+				if (splitted.length > 1) {
+					trigger = MobTrigger.getOrCreate(splitted[1], dsign.getGameWorld());
+				}
+
 			}
 		}
 		return trigger;

--- a/src/com/dre/dungeonsxl/trigger/Trigger.java
+++ b/src/com/dre/dungeonsxl/trigger/Trigger.java
@@ -45,6 +45,12 @@ public abstract class Trigger {
 					trigger = SignTrigger.getOrCreate(P.p.parseInt(splitted[1]), dsign.getGameWorld());
 				}
 
+			} else if (splitted[0].equalsIgnoreCase("I")) {
+
+				if (splitted.length > 1) {
+					trigger = InteractTrigger.getOrCreate(P.p.parseInt(splitted[1]), dsign.getGameWorld());
+				}
+
 			}
 		}
 		return trigger;

--- a/src/com/dre/dungeonsxl/trigger/UseItemTrigger.java
+++ b/src/com/dre/dungeonsxl/trigger/UseItemTrigger.java
@@ -1,0 +1,77 @@
+package com.dre.dungeonsxl.trigger;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.ArrayList;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import com.dre.dungeonsxl.game.GameWorld;
+
+
+public class UseItemTrigger extends Trigger {
+
+	private static Map<GameWorld, ArrayList<UseItemTrigger>> triggers = new HashMap<GameWorld, ArrayList<UseItemTrigger>>();
+
+	private String name;
+	private String matchedName;
+
+	public UseItemTrigger(String name) {
+		this.name = name;
+		Material mat = Material.matchMaterial(name);
+		if (mat != null) {
+			this.matchedName = mat.toString();
+		}
+	}
+
+	public void onTrigger(Player player) {
+		triggered = true;
+		this.player = player;
+		updateDSigns();
+	}
+
+	public void register(GameWorld gworld) {
+		if (!hasTriggers(gworld)) {
+			ArrayList<UseItemTrigger> list = new ArrayList<UseItemTrigger>();
+			list.add(this);
+			triggers.put(gworld, list);
+		} else {
+			triggers.get(gworld).add(this);
+		}
+	}
+
+	public void unregister(GameWorld gworld) {
+		if (hasTriggers(gworld)) {
+			triggers.get(gworld).remove(this);
+		}
+	}
+
+	public static UseItemTrigger getOrCreate(String name, GameWorld gworld) {
+		UseItemTrigger trigger = get(name, gworld);
+		if (trigger != null) {
+			return trigger;
+		}
+		return new UseItemTrigger(name);
+	}
+
+	public static UseItemTrigger get(String name, GameWorld gworld) {
+		if (hasTriggers(gworld)) {
+			for (UseItemTrigger trigger : triggers.get(gworld)) {
+				if (trigger.name.equalsIgnoreCase(name)) {
+					return trigger;
+				} else {
+					if (trigger.matchedName != null) {
+						if (trigger.matchedName.equalsIgnoreCase(name)) {
+							return trigger;
+						}
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	public static boolean hasTriggers(GameWorld gworld) {
+		return !triggers.isEmpty() && triggers.containsKey(gworld);
+	}
+
+}


### PR DESCRIPTION
Änderungen die an existierenden Dungeons gemacht werden müssen: _KEINE_

---

Das Triggersystem wurde komplett überarbeitet. Es ist nun ganz einfach möglich weitere Trigger hinzuzufügen.

Außerdem wurde ein Interact Schild hinzugefügt, welches wie ein anklickbares Triggerschild funktioniert.
Ready, Leave, End schilder sind standardmäßig Interact Schilder, können nun aber auch durch andere Trigger getriggert werden.

Die Trigger Mob Death und Use Item wurden hinzugefügt
Das Redstone Schild hat neue Funktionen
Checkpoint können nun auch von einzelnen Spielern erreicht werden

Trigger brauchen keine Leerzeichen mehr: "D 2, R , T 1" geht genauso wie "D2,R,T1"

Alle Änderungen an den Schildern sind bereits ins Wiki eingepflegt und sind dort im Detail beschrieben.
